### PR TITLE
Fulfill tests

### DIFF
--- a/healthz.go
+++ b/healthz.go
@@ -13,8 +13,8 @@ func init() {
 	})
 }
 
-func OK(addr string, timeout int) error {
-	client := &http.Client{Timeout: time.Duration(timeout) * time.Second}
+func OK(addr string, timeout time.Duration) error {
+	client := &http.Client{Timeout: timeout}
 	resp, e := client.Get("http://" + addr + "/healthz")
 	if e != nil {
 		return e

--- a/healthz_test.go
+++ b/healthz_test.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -11,13 +12,17 @@ import (
 func TestOK(t *testing.T) {
 	assert := assert.New(t)
 
-	assert.NotNil(OK(":12345", 1))
+	assert.NotNil(OK(":12345", time.Second))
 
 	l, e := net.Listen("tcp", ":0") // OS allocates a free port.
 	if e != nil {
 		t.Skip("Mocking healthz server cannot listen: ", e)
 	}
-	go http.Serve(l, nil)
+	go func() {
+		time.Sleep(2 * time.Second) // Artificial delay
+		http.Serve(l, nil)
+	}()
 
-	assert.Nil(OK(l.Addr().String(), 1))
+	assert.NotNil(OK(l.Addr().String(), 1*time.Second)) // Less than delay
+	assert.Nil(OK(l.Addr().String(), 3*time.Second))    // Longer than delay
 }


### PR DESCRIPTION
This auxiliary package enables 
1. HTTP/RPC servers to export their healthiness  via URL `<addr>/healthz` by simply import this package, and
2. clients can call `healthz.OK(server, timeout)` to wait until the server starts up or timeout.
